### PR TITLE
[WIP] Sloppy First Attempt at Supporting `index` in `create_table`

### DIFF
--- a/lib/chrono_model/adapter.rb
+++ b/lib/chrono_model/adapter.rb
@@ -15,6 +15,8 @@ module ChronoModel
   # adapter for a clean override of its methods using super.
   #
   class Adapter < ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+    alias parent_add_index add_index
+
     include ChronoModel::Adapter::Migrations
     include ChronoModel::Adapter::DDL
     include ChronoModel::Adapter::Indexes

--- a/lib/chrono_model/adapter/migrations.rb
+++ b/lib/chrono_model/adapter/migrations.rb
@@ -6,7 +6,7 @@ module ChronoModel
       # Creates the given table, possibly creating the temporal schema
       # objects if the `:temporal` option is given and set to true.
       #
-      def create_table(table_name, **options)
+      def create_table(table_name, **options, &block)
         # No temporal features requested, skip
         return super unless options[:temporal]
 
@@ -19,7 +19,16 @@ module ChronoModel
 
         transaction do
           on_temporal_schema { super }
-          on_history_schema { chrono_history_table_ddl(table_name) }
+          on_history_schema do
+            chrono_history_table_ddl(table_name)
+
+            td = build_create_table_definition(table_name, **options, &block)
+
+            td.indexes.each do |column_name, index_options|
+              index_options = index_options.dup.tap { |o| o.delete(:unique) } if index_options[:unique].present?
+              parent_add_index(table_name, column_name, **index_options, if_not_exists: td.if_not_exists)
+            end
+          end
 
           chrono_public_view_ddl(table_name, options)
         end

--- a/spec/chrono_model/adapter/migrations_spec.rb
+++ b/spec/chrono_model/adapter/migrations_spec.rb
@@ -48,6 +48,63 @@ RSpec.describe ChronoModel::Adapter do
 
       it_behaves_like 'plain table'
     end
+
+    context 'when #index and #references is called on the table definition' do
+      let(:columns) do
+        native = [['foo', 'character varying']]
+
+        def native.to_proc
+          proc { |t|
+            t.string :foo
+            t.string :baz
+            t.string :tar
+
+            t.index :foo
+            t.index :baz, name: 'baz_index'
+            t.index %i[foo baz], name: 'foo_baz_index'
+            t.references :bar, index: true
+            t.index :tar, unique: true
+          }
+        end
+
+        native
+      end
+
+      context 'with temporal tables' do
+        include_context 'with temporal tables'
+
+        it_behaves_like 'temporal table'
+
+        it { is_expected.to have_temporal_index "index_#{table}_on_foo",    %w[foo] }
+        it { is_expected.to have_history_index  "index_#{table}_on_foo",    %w[foo] }
+        it { is_expected.to have_temporal_index 'baz_index',                %w[baz] }
+        it { is_expected.to have_history_index  'baz_index',                %w[baz] }
+        it { is_expected.to have_temporal_index 'foo_baz_index',            %w[foo baz] }
+        it { is_expected.to have_history_index  'foo_baz_index',            %w[foo baz] }
+        it { is_expected.to have_temporal_index "index_#{table}_on_bar_id", %w[bar_id] }
+        it { is_expected.to have_history_index  "index_#{table}_on_bar_id", %w[bar_id] }
+        it { is_expected.to have_temporal_unique_index    "index_#{table}_on_tar", %w[tar] }
+        it { is_expected.not_to have_history_unique_index "index_#{table}_on_tar", %w[tar] }
+
+        it { is_expected.not_to have_index "index_#{table}_on_foo",    %w[foo] }
+        it { is_expected.not_to have_index 'baz_index',                %w[baz] }
+        it { is_expected.not_to have_index 'foo_baz_index',            %w[foo baz] }
+        it { is_expected.not_to have_index "index_#{table}_on_bar_id", %w[bar_id] }
+        it { is_expected.not_to have_index "index_#{table}_on_tar",    %w[tar] }
+      end
+
+      context 'with plain tables' do
+        include_context 'with plain tables'
+
+        it_behaves_like 'plain table'
+
+        it { is_expected.to have_index "index_#{table}_on_foo",    %w[foo] }
+        it { is_expected.to have_index 'baz_index',                %w[baz] }
+        it { is_expected.to have_index 'foo_baz_index',            %w[foo baz] }
+        it { is_expected.to have_index "index_#{table}_on_bar_id", %w[bar_id] }
+        it { is_expected.to have_unique_index "index_#{table}_on_tar", %w[tar] }
+      end
+    end
   end
 
   describe '.rename_table' do
@@ -243,6 +300,7 @@ RSpec.describe ChronoModel::Adapter do
         adapter.add_index table, %i[foo bar], name: 'foobar_index'
         adapter.add_index table, [:test], name: 'test_index'
         adapter.add_index table, :baz
+        adapter.add_index table, %i[foo baz], name: 'foobaz_index', unique: true
       end
 
       it { is_expected.to have_temporal_index 'foobar_index', %w[foo bar] }
@@ -251,10 +309,12 @@ RSpec.describe ChronoModel::Adapter do
       it { is_expected.to have_history_index  'test_index',   %w[test] }
       it { is_expected.to have_temporal_index 'index_test_table_on_baz', %w[baz] }
       it { is_expected.to have_history_index  'index_test_table_on_baz', %w[baz] }
+      it { is_expected.to have_temporal_unique_index 'foobaz_index', %w[foo baz] }
 
       it { is_expected.not_to have_index 'foobar_index', %w[foo bar] }
       it { is_expected.not_to have_index 'test_index',   %w[test] }
       it { is_expected.not_to have_index 'index_test_table_on_baz', %w[baz] }
+      it { is_expected.not_to have_history_unique_index 'foobaz_index', %w[foo baz] }
     end
 
     context 'with plain tables' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require 'support/matchers/schema'
 require 'support/matchers/table'
 require 'support/matchers/column'
 require 'support/matchers/index'
+require 'support/matchers/unique_index'
 require 'support/matchers/function'
 require 'support/matchers/source'
 require 'support/aruba'
@@ -41,6 +42,7 @@ RSpec.configure do |config|
   config.include(ChronoTest::Matchers::Table)
   config.include(ChronoTest::Matchers::Column)
   config.include(ChronoTest::Matchers::Index)
+  config.include(ChronoTest::Matchers::UniqueIndex)
   config.include(ChronoTest::Matchers::Function)
   config.include(ChronoTest::Matchers::Source)
   config.include(ChronoTest::Aruba, type: :aruba)

--- a/spec/support/matchers/unique_index.rb
+++ b/spec/support/matchers/unique_index.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module ChronoTest
+  module Matchers
+    module UniqueIndex
+      class HaveUniqueIndex < ChronoTest::Matchers::Base
+        attr_reader :name, :columns, :schema
+
+        def initialize(name, columns, schema = 'public')
+          @name    = name
+          @columns = columns.sort
+          @schema  = schema
+        end
+
+        def description
+          'have unique index'
+        end
+
+        def matches?(table)
+          super
+
+          select_values(<<~SQL.squish, [table, name, schema], 'Check index') == columns
+            SELECT a.attname
+              FROM pg_class t
+              JOIN pg_index d ON t.oid = d.indrelid
+              JOIN pg_class i ON i.oid = d.indexrelid
+              JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(d.indkey)
+             WHERE i.relkind = 'i'
+               AND d.indisunique = true
+               AND t.relname = ?
+               AND i.relname = ?
+               AND i.relnamespace = (
+                SELECT oid FROM pg_namespace WHERE nspname = ?
+              )
+             ORDER BY a.attname
+          SQL
+        end
+
+        def failure_message
+          "expected #{schema}.#{table} to have a #{name} unique index on #{columns}"
+        end
+
+        def failure_message_when_negated
+          "expected #{schema}.#{table} to not have a #{name} unique index on #{columns}"
+        end
+      end
+
+      def have_unique_index(*args)
+        HaveUniqueIndex.new(*args)
+      end
+
+      class HaveTemporalUniqueIndex < HaveUniqueIndex
+        def initialize(name, columns)
+          super(name, columns, temporal_schema)
+        end
+      end
+
+      def have_temporal_unique_index(*args)
+        HaveTemporalUniqueIndex.new(*args)
+      end
+
+      class HaveHistoryUniqueIndex < HaveUniqueIndex
+        def initialize(name, columns)
+          super(name, columns, history_schema)
+        end
+      end
+
+      def have_history_unique_index(*args)
+        HaveHistoryUniqueIndex.new(*args)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to https://github.com/ifad/chronomodel/issues/173

This branch is based on another branch of mine which refactors the specs. A PR is up for that branch here: https://github.com/ifad/chronomodel/pull/347

The goal here is just to get feedback on the general approach.

### Background

The issue seems to arise from the fact that `ChronoModel::Adapter::Migrations#create_table` calls `super` for the temporal schema, but not the history schema.

This makes sense since the history table inherits from the temporal table. However, PostgreSQL's table inheritance doesn't include indices.

So for columns, we want to rely on inheritance rather than the table definition from `#create_table`. But for indices, we can't rely on inheritance so we need to use the table definition from `#create_table`. 

### Solution

My solution is to call the AR method `#build_create_table_definition` which has the same call signature as `#create_table` and just creates the table definition. From this table definition, we can extract just the indexes and execute those by calling `#add_index`.

Something similar happens in `ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements#create_table`. The table definition is created, everything in it except indexes gets executed, and then they're created separately in a loop with `#add_index`.

You can find this procedure here: [active_record/connection_adapters/abstract/schema_statements.rb:293](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L293)

I'm not sure aliasing the parent class's `#add_index` is the best approach. And in any case the code would definitely need to be cleaned up.